### PR TITLE
Use Scalar JRE8 base image

### DIFF
--- a/ist-loader/Dockerfile
+++ b/ist-loader/Dockerfile
@@ -1,15 +1,4 @@
-FROM openjdk:8u275-jre-slim
-
-# Fix CVE-2021-3520, CVE-2021-33560, CVE-2021-20231, CVE-2021-20232, CVE-2020-24659, sCVE-2021-20305 and CVE-2021-23840
-RUN apt-get update && apt-get install -y netcat && apt-get install -y --no-install-recommends \
-    liblz4-1=1.8.3-1+deb10u1 \
-    libgcrypt20=1.8.4-5+deb10u1 \
-    libgnutls30=3.6.7-4+deb10u7 \
-    libhogweed4=3.4.1-1+deb10u1 \
-    libnettle6=3.4.1-1+deb10u1 \
-    libssl1.1=1.1.1d-0+deb10u7 \
-    openssl=1.1.1d-0+deb10u7 \
-    && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/scalar-labs/jre8:1.1.6
 
 # Copy all necessary files to the image
 COPY docker-files/scalar-ist-loader .


### PR DESCRIPTION
The IST loader was still using a custom JRE docker image with fixes. Replaced with the scalar base image.