### PR TITLE
Upgrade scalardb-schema-loader 3.6.0

### DIFF
--- a/ist-schema-loader/Dockerfile
+++ b/ist-schema-loader/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/scalar-labs/scalardb-schema-loader:3.1.1
+FROM ghcr.io/scalar-labs/scalardb-schema-loader:3.6.0
 COPY schema/ist.transaction.json schema.json
 ENTRYPOINT ["java", "-jar", "app.jar", "-f", "schema.json"]


### PR DESCRIPTION
This PR upgrades the scalardb-schema-loader to 3.6.0