### PR TITLE
Fix order of user profile commands and remove $

### DIFF
--- a/docs/how_to_use.md
+++ b/docs/how_to_use.md
@@ -55,136 +55,136 @@ ISTでは、以下の順番で事業者、およびユーザープロファイ�
 
 ## デプロイツールのビルド
 ```
-$ ./gradlew installDist
+./gradlew installDist
 ```
 
 ## ISTで使用する共有のファンクションを登録
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/functions.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/functions.json
 ```
 
 # システム運用事業者、個人情報取扱事業者の情報を登録
 ## システム運用事業者を登録
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/initialize.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/initialize.json
 ```
 
 ## 個人情報取扱事業者の登録
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/register_company.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/register_company.json
 ```
 
 ## 個人情報取扱事業者のユーザプロファイル情報を登録
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/upsert_user_profile_controller.json
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/upsert_user_profile_admin.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/upsert_user_profile_admin.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/upsert_user_profile_controller.json 
 ```
 
 # 同意文書のマスタ情報を登録
 ## 利用目的を登録する
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/register_purpose.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/register_purpose.json
 ```
 
 ## 利用目的を更新する
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_purpose.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_purpose.json
 ```
 
 ## データセットスキーマを登録する
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/register_data_set_schema.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/register_data_set_schema.json
 ```
 
 ## データセットスキーマを更新する
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_data_set_schema.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_data_set_schema.json
 ```
 
 ## 第三者提供先を登録する
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/register_third_party.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/register_third_party.json
 ```
 
 ## 第三者提供先を更新する
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_third_party.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_third_party.json
 ```
 
 ## 利用停止、データ削除期限を登録する
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/register_data_retention_policy.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/register_data_retention_policy.json
 ```
 
 ## 利用停止、データ削除期限を更新する
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_data_retention_policy.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_data_retention_policy.json
 ```
 
 ## 便益を登録する
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/register_benefit.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/register_benefit.json
 ```
 
 ## 便益を更新する
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_benefit.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_benefit.json
 ```
 
 # 同意文書の登録、更新
 ## 同意文書を登録する
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/register_consent_statement.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/register_consent_statement.json
 ```
 
 ## 同意文書を修正する（再同意が不要な変更内容）
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_consent_statement_revision.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_consent_statement_revision.json
 ```
 
 ## 同意文書を改訂する（再同意が必要な変更内容）
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_consent_statement_version.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_consent_statement_version.json
 ```
 
 ## 同意文書のステータスを変更する
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_consent_statement_status.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_consent_statement_status.json
 ```
 
 # 事業者情報の更新
 ## 事業者ユーザの所属組織の更新
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_company.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/update_company.json
 ```
 
 ## 事業者ユーザのロールの更新
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/upsert_user_profile_controller_add_processor.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/upsert_user_profile_controller_add_processor.json
 ```
 
 ## 組織情報の追加・更新
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/upsert_organization.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/upsert_organization.json
 ```
 
 # データ主体による同意の記録
 ## 同意の登録
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/upsert_consent_status_register.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/upsert_consent_status_register.json
 ```
 
 ## 同意の更新
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/upsert_consent_status_update.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/upsert_consent_status_update.json
 ```
 
 ## データ主体により同意の状態の参照
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/get_consent_status_data_subject.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/get_consent_status_data_subject.json
 ```
 
 ## 事業者ユーザーによる同意の状態の参照
 ```
-$ build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/get_consent_status_controller.json
+build/install/deploy_tool/bin/deploy_tool -f build/resources/main/command/get_consent_status_controller.json
 ```


### PR DESCRIPTION
This PR fixes the contract execution order related to the user profile commands.
It also removes the $ that is prefixing the code blocks. It makes it much easier to just copy the code.