### PR TITLE
Add shell script tool to register system operator

### DIFF
--- a/tools/deploy/fixture/argument/initialize
+++ b/tools/deploy/fixture/argument/initialize
@@ -1,0 +1,16 @@
+INITIALIZE_ARG='{
+	"company_id": "service-operator.com",
+	"company_name": "Service Operator",
+	"corporate_number": "6010001188571",
+	"company_metadata": {
+		"third_party_name": "Service Operator, Inc.",
+		"address": "東京都新宿区",
+		"email": "mail@service-operator.com"
+	},
+	"organization_id": "8d8f6623-30e5-40a0-982d-54ad1e629c38",
+	"sysadmin_holder_id": "61b1af48-75f7-4626-af37-2d9973c7a5c2",
+	"sysoperator_holder_id": "967e4495-90e9-473a-82fd-99fba3218b22",
+	"created_at": 1663141340442,
+	"_functions_": ["Initialize"],
+	"holder_id": "Initializer"
+}'

--- a/tools/deploy/fixture/schema/argument/initialize
+++ b/tools/deploy/fixture/schema/argument/initialize
@@ -1,0 +1,86 @@
+INITIALIZE_PROP='{
+ 	"contract_argument_schema": {
+ 		"$schema": "http://json-schema.org/draft-07/schema#",
+ 		"type": "object",
+ 		"required": [
+ 		  "company_id",
+ 		  "company_name",
+ 		  "company_metadata",
+ 		  "organization_id",
+ 		  "sysadmin_holder_id",
+ 		  "sysoperator_holder_id",
+ 		  "created_at"
+ 		],
+ 		"properties": {
+ 			"executor_holder_id": {
+ 				"const": "Initializer"
+ 			},
+ 			"company_id": {
+ 				"type": "string",
+ 				"format": "hostname"
+ 			},
+ 			"company_name": {
+ 				"type": "string",
+ 				"minLength": 1
+ 			},
+ 			"corporate_number": {
+ 				"type": "string",
+ 				"pattern": "^[0-9]{0,13}$"
+ 			},
+ 			"company_metadata": {
+ 				"type": "object"
+ 			},
+ 			"organization_id": {
+ 				"type": "string",
+ 				"pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+ 			},
+ 			"sysadmin_holder_id": {
+ 				"type": "string",
+ 				"pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+ 			},
+ 			"sysoperator_holder_id": {
+ 				"type": "string",
+ 				"pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+ 			},
+ 			"created_at": {
+ 				"type": "integer",
+ 				"minimum": 0
+ 			}
+ 		}
+ 	},
+ 	"company_asset_name": "cp",
+ 	"company_asset_version": "01",
+ 	"user_profile_asset_name": "up",
+ 	"user_profile_asset_version": "01",
+ 	"holder_id": "Initializer"
+}'
+
+PUT_ASSET_RECORD_PROP='{
+	"contract_argument_schema": {
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"type": "object",
+		"required": ["asset_id", "data", "mode", "is_hashed", "created_at"],
+		"properties": {
+			"asset_id": {
+				"type": "string",
+				"pattern": "^[a-zA-Z0-9-/_.]+$"
+			},
+			"data": {
+				"type": "object"
+			},
+			"mode": {
+				"type": "string",
+				"enum": ["insert", "update", "upsert"]
+			},
+			"is_hashed": {
+				"type": "boolean"
+			},
+			"created_at": {
+				"type": "integer",
+				"minimum": 0
+			}
+		}
+	},
+	"salt": "salt",
+	"holder_id": "Initializer"
+}'

--- a/tools/deploy/initialize
+++ b/tools/deploy/initialize
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+PRG="$0"
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+CURRENT_DIR="`pwd`"
+cd "`dirname \"$PRG\"`"/../../ >/dev/null
+ROOTDIR="`pwd -P`"
+cd "$CURRENT_DIR" >/dev/null
+
+source "${CURRENT_DIR}/common.sh"
+source "${CURRENT_DIR}/fixture/argument/initialize"
+source "${CURRENT_DIR}/fixture/schema/argument/initialize"
+
+run register_certificate "${CURRENT_DIR}/fixture/conf/initializer.properties"
+
+run register_contract "${CURRENT_DIR}/fixture/conf/initializer.properties" \
+  "PutAssetRecord" \
+  "com.scalar.ist.contract.PutAssetRecord" \
+  "${ROOTDIR}/contracts_and_functions/build/classes/java/main/com/scalar/ist/contract/PutAssetRecord.class" \
+  "PUT_ASSET_RECORD_PROP"
+
+run register_contract "${CURRENT_DIR}/fixture/conf/initializer.properties" \
+  "ValidateArgument" \
+  "com.scalar.ist.contract.ValidateArgument" \
+  "${ROOTDIR}/contracts_and_functions/build/classes/java/main/com/scalar/ist/contract/ValidateArgument.class"
+
+run register_contract "${CURRENT_DIR}/fixture/conf/initializer.properties" \
+  "Initialize" \
+  "com.scalar.ist.contract.Initialize" \
+  "${ROOTDIR}/contracts_and_functions/build/classes/java/main/com/scalar/ist/contract/Initialize.class" \
+  "INITIALIZE_PROP"
+
+run execute_contract "${CURRENT_DIR}/fixture/conf/initializer.properties" \
+  "Initialize" \
+  "INITIALIZE_ARG"


### PR DESCRIPTION
Add shell script tool to register system operator instead of current java deploy-tool.
* [command/initialize.json](https://github.com/scalar-labs/scalar-ist/tree/main/tools/deploy_tool/src/main/resources/command/initialize.json)  -> `tools/deploy/initialize`
* [argument/initialize.json](https://github.com/scalar-labs/scalar-ist/tree/main/tools/deploy_tool/src/main/resources/argument/initialize.json) -> `tools/deploy/fixture/argument/initialize`
* [schema/argument/initialize.json](https://github.com/scalar-labs/scalar-ist/tree/main/tools/deploy_tool/src/main/resources/schema/argument/initialize.json) -> `tools/deploy/fixture/schema/argument/initialize`