### PR TITLE
Add CI build to scalar-ist project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push
+#  pull_request:
+#    branches:
+#      - master
+#      - '*'
+
+jobs:
+  scalar-ist-ci-tests:
+
+    runs-on: ubuntu-18.04
+    env:
+      CONTRACTS_AND_FUNCTIONS_DIR: ${{ github.workspace }}/contracts_and_functions
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Cache
+        uses: actions/cache@v1.1.2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Run unit tests
+        run: |
+          cd ${{ env.CONTRACTS_AND_FUNCTIONS_DIR }}
+          ./gradlew test
+
+      - name: Build scalar-ist contracts and functions
+        run: |
+          cd ${{ env.CONTRACTS_AND_FUNCTIONS_DIR }}
+          ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,10 @@
 name: CI
 
 on:
-  push
-#  pull_request:
-#    branches:
-#      - master
-#      - '*'
+  pull_request:
+    branches:
+      - master
+      - '*'
 
 jobs:
   scalar-ist-ci-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,9 @@ jobs:
           cd ${{ env.CONTRACTS_AND_FUNCTIONS_DIR }}
           ./gradlew check
 
-      - name: Build scalar-ist contracts and functions
+      - name: Cleanup Gradle cache
+        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
         run: |
-          cd ${{ env.CONTRACTS_AND_FUNCTIONS_DIR }}
-          ./gradlew build
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Run unit tests
+      - name: Gradle check
         run: |
           cd ${{ env.CONTRACTS_AND_FUNCTIONS_DIR }}
-          ./gradlew test
+          ./gradlew check
 
       - name: Build scalar-ist contracts and functions
         run: |


### PR DESCRIPTION
Add CI for scalar-ist contracts and functions.

Deploy tool not added to CI because it will be removed soon.