### PR TITLE
Fix broken link in the README of ist-schema-loader

### DIFF
--- a/ist-schema-loader/README.md
+++ b/ist-schema-loader/README.md
@@ -20,7 +20,7 @@ docker push <tag>
 ## How to use
 
 Check out the Schema tool documentation for the correct usage.
-[link](https://github.com/scalar-labs/scalardb/blob/master/tools/scalar-schema/README.md)
+[link](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md)
 
 docker-compose.yaml
 


### PR DESCRIPTION
It seems that the URL (link to ScalarDB Schema Loader document) in the README of `ist-schema-loader` is broken. 
It returns a 404 error.
This PR fixes that broken link. Please take a look!